### PR TITLE
Dragging the map sticks to the cursor more accurately

### DIFF
--- a/main.lua
+++ b/main.lua
@@ -83,8 +83,8 @@ end
 local function WorldMapScrollFrame_OnPan(cursorX, cursorY)
 	local dX = WorldMapScrollFrame.cursorX - cursorX
 	local dY = cursorY - WorldMapScrollFrame.cursorY
-	dX = dX / WorldMapDetailFrame:GetScale()
-	dY = dY / WorldMapDetailFrame:GetScale()
+	dX = dX / this:GetEffectiveScale()
+	dY = dY / this:GetEffectiveScale()
 	if abs(dX) >= 1 or abs(dY) >= 1 then
 		WorldMapScrollFrame.moved = true
 

--- a/main.lua
+++ b/main.lua
@@ -83,6 +83,8 @@ end
 local function WorldMapScrollFrame_OnPan(cursorX, cursorY)
 	local dX = WorldMapScrollFrame.cursorX - cursorX
 	local dY = cursorY - WorldMapScrollFrame.cursorY
+	dX = dX / WorldMapDetailFrame:GetScale()
+	dY = dY / WorldMapDetailFrame:GetScale()
 	if abs(dX) >= 1 or abs(dY) >= 1 then
 		WorldMapScrollFrame.moved = true
 


### PR DESCRIPTION
Fixes #13 

Changes the click+drag behavior to move at the same speed as the cursor, rather than moving faster the more you zoom in.

Before:

https://github.com/user-attachments/assets/700cb413-7c38-4de6-b724-286895dc3712

After:

https://github.com/user-attachments/assets/bf065bcf-0a35-4668-8418-978ec932085a

