### PR TITLE
Scale player arrow inversely with map zoom level

### DIFF
--- a/main.lua
+++ b/main.lua
@@ -121,6 +121,13 @@ local function WorldMapButton_OnUpdate()
 
 		WorldMapPlayer:SetPoint('CENTER', this, 'TOPLEFT', x, y)
 
+		-- scale arrow inversely to map zoom so it doesn't grow when zoomed in
+		local mapScale = WorldMapDetailFrame:GetScale()
+		local baseSize = 24 * (Magnify_Settings['arrow_scale'] or 1)
+		local scaledSize = baseSize / mapScale
+		WorldMapPlayer.Icon:SetWidth(scaledSize)
+		WorldMapPlayer.Icon:SetHeight(scaledSize)
+
 		-- credit: https://wowwiki-archive.fandom.com/wiki/SetTexCoord_Transformations
 		local s = sqrt(2)
 		local r = WorldMapPlayerModel:GetFacing()


### PR DESCRIPTION
## Summary
- Player arrow on the world map no longer grows oversized when zooming in
- Arrow size is divided by the current map scale each frame, keeping it visually consistent at all zoom levels
- Respects the user's `arrow_scale` setting

## Changed
- `main.lua`: Added inverse scaling in `WorldMapButton_OnUpdate` (lines 124-129)


BEFORE (4x zoom):
<img width="634" height="446" alt="image" src="https://github.com/user-attachments/assets/fd06dae7-4ee8-4095-8f1a-c3b88fba8a0a" />


NOW:
<img width="634" height="446" alt="image" src="https://github.com/user-attachments/assets/f7be1408-c3e3-4e21-9108-2d56701f87fd" />

